### PR TITLE
feat: Allow `${workspaceFolder}` in `vala.languageServerPath` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.0
+- Allow `${workspaceFolder}` in `vala.languageServerPath` configuration
+
 ## 1.0.4
 - Updated grammars
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vala",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vala",
-      "version": "1.0.8",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "8.0.0-next.14",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vala",
   "displayName": "Vala",
   "description": "Syntax highlighting and language support for the Vala / Genie languages",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "publisher": "prince781",
   "author": {
     "name": "Princeton Ferro",

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,6 +24,19 @@ import {
 
 import * as which from 'which'
 
+const VarRegex = new RegExp(/\$\{(\w+)\}/g);
+function substituteVSCodeVariableInString(val: string): string {
+    return val.replace(VarRegex, (substring: string, varName) => {
+        if (varName === "workspaceFolder") {
+            const folders = workspace.workspaceFolders ?? [];
+            if (folders.length >= 1) {
+                return folders[0].uri.fsPath;
+            }
+        }
+        return substring;
+    });
+}
+
 export class ValaLanguageClient {
 
     config: WorkspaceConfiguration
@@ -79,7 +92,7 @@ export class ValaLanguageClient {
     }
 
     get languageServerPath(): string | null {
-        return this.config.languageServerPath
+        return substituteVSCodeVariableInString(this.config.languageServerPath)
              || which.sync('vala-language-server', { nothrow: true })
              || which.sync('org.gnome.gvls.stdio.Server', { nothrow: true })
              || which.sync('gvls', { nothrow: true })   // for legacy GVLS


### PR DESCRIPTION
The predefined VSCode variables [1] are not automatically substituted for configuration options. The Vala extension must do the substitution to allow the Vala language server to be relative to the workspace folder.

This patch is a simplified version of the substitution in the Rust extension [2].

[1]: https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables
[2]: https://github.com/rust-lang/rust-analyzer/blob/884dd8c966e29d48bd9f8e5f22440cd238aa7cf1/editors/code/src/config.ts#L399