### PR TITLE
set standard id without spaces

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -83,7 +83,7 @@ export class ValaLanguageClient {
             debug: debugExe
         };
 
-        this.ls = new LanguageClient('Vala Language Server', serverOptions, clientOptions);
+        this.ls = new LanguageClient('vala-language-server', 'Vala Language Server', serverOptions, clientOptions);
 
         commands.registerTextEditorCommand('vala.showBaseSymbol', this.peekSymbol);
         commands.registerTextEditorCommand('vala.showHiddenSymbol', this.peekSymbol);


### PR DESCRIPTION
https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server

logging support from vscode-languageclient uses

    langId.trace.server = verbose

but as vala-vscode uses LanguageClient constructor that defines both id and name, id has spaces and capital letters and probably that confuses the config. None of this works:

    "Vala Language Server3.trace.server": "verbose",    
    "Vala\\ Language\\ Server3.trace.server": "verbose",

with this change:

    "vala-language-server.trace.server": "verbose"

works and allow to see all communications

