### PR TITLE
fix unexpected crash of vala-language-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,17 @@
           "vala"
         ],
         "extensions": [
-          ".vala",
+          ".vala"
+        ],
+        "configuration": "./language-configuration-vala.json"
+      },
+      {
+        "id": "vapi",
+        "aliases": [
+          "Vapi",
+          "vapi"
+        ],
+        "extensions": [
           ".vapi"
         ],
         "configuration": "./language-configuration-vala.json"
@@ -54,6 +64,11 @@
     "grammars": [
       {
         "language": "vala",
+        "scopeName": "source.vala",
+        "path": "./syntaxes/vala.tmLanguage"
+      },
+      {
+        "language": "vapi",
         "scopeName": "source.vala",
         "path": "./syntaxes/vala.tmLanguage"
       },


### PR DESCRIPTION
When click the link in the red box in the picture, vala-language-server will crash unexpectedly.

Solve it by using different processing methods for `.vapi` files.

![crash](https://github.com/user-attachments/assets/b568a8cf-72bb-459f-8cb7-8f4551ef8612)
